### PR TITLE
Assesment tagless final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.corerda"
 name := "MapNet"
-version := "0.1.0-SNAPSHOT"
+version := "0.1.1-SNAPSHOT"
 
 scalaVersion := "2.13.10"
 

--- a/src/main/scala/org/corerda/entities/Cardinal.scala
+++ b/src/main/scala/org/corerda/entities/Cardinal.scala
@@ -1,5 +1,7 @@
 package org.corerda.entities
 
+// the Cardinal number for Domain superset of the functions
+// it's meant to hold the Task pointers
 sealed trait Cardinal[+A]
 case object Zero extends Cardinal[Nothing] with Product with Serializable
 final case class One[+A](value: A) extends Cardinal[A] with Product with Serializable

--- a/src/main/scala/org/corerda/entities/ExprTree.scala
+++ b/src/main/scala/org/corerda/entities/ExprTree.scala
@@ -1,0 +1,13 @@
+package org.corerda.entities
+
+
+case class ExprTree[+A](value: A)
+
+// TODO - review semantic redundancy with Task and Cardinal
+// Tag-less Final FoldedTree
+object ExprTree {
+  def leaf[A](ops: Reader[A]): ExprTree[A] = ExprTree(ops.read)
+  def stem[A](ops: Transformer[A])(prev: ExprTree[A]): ExprTree[A] = ExprTree(ops.f(prev.value))
+  def branch[A](ops: Binder[A])(left: ExprTree[A], right: ExprTree[A]): ExprTree[A] = ExprTree(ops.bind(left.value, right.value))
+  def root[A](ops: Writer[A])(prev: ExprTree[A]): ExprTree[A] = ExprTree(ops.write(prev.value))
+}

--- a/src/main/scala/org/corerda/entities/Tree.scala
+++ b/src/main/scala/org/corerda/entities/Tree.scala
@@ -1,5 +1,7 @@
 package org.corerda.entities
 
+
+// @ Deprecated
 trait Tree[+A]
 object Tree {
   def leaf[A](value: A): Tree[A] = Leaf(value)

--- a/src/main/scala/org/corerda/rules/core/Job.scala
+++ b/src/main/scala/org/corerda/rules/core/Job.scala
@@ -2,14 +2,15 @@ package org.corerda.rules.core
 
 import org.corerda.entities._
 
+
+// @deprecated
 object Job {
   type Job[A] = Tree[Task[A]]
-  def foldTree[A](job: Job[A]): A = job match {
+  def eval[A](job: Job[A]): A = job match {
     case Leaf(task: Reader[A]) => task.read
-    case Stem(task: Writer[A], next) => task.write(foldTree(next))
-    case Stem(task: Transformer[A], next) => task.f(foldTree(next))
+    case Stem(task: Writer[A], next) => task.write(eval(next))
+    case Stem(task: Transformer[A], next) => task.f(eval(next))
     case Branch(task: Binder[A], left, right) =>
-      task.bind(foldTree(left), foldTree(right))
+      task.bind(eval(left), eval(right))
   }
 }
-

--- a/src/test/scala/org/corerda/UnSafeRunner.scala
+++ b/src/test/scala/org/corerda/UnSafeRunner.scala
@@ -8,13 +8,15 @@ import org.corerda.rules.core.TreeOps._
 import org.corerda.service.provider.FileProvider
 import org.corerda.service.types.IntegerImpl
 
+// TODO
+//  - delete deprecated Classes
+//  - redo Unit tests
 object UnSafeRunner extends App {
   type set = IntegerImpl.myType
 
   val planCfg = FileProvider.fromPath("src/test/resources/playground/plans/intGraph.yaml")
   implicit val decoder: Decoder[Node[set]] = IntegerImpl.taskDecoder
   val graph = fromString[set](planCfg)
-  val treeGraph = toTree(graph)
 
-  treeGraph.map(foldTree)
+  runAST(graph)
 }

--- a/src/test/scala/org/corerda/rules/core/JobTest.scala
+++ b/src/test/scala/org/corerda/rules/core/JobTest.scala
@@ -4,6 +4,7 @@ import org.corerda.entities._
 import org.scalatest.funspec.AnyFunSpec
 
 
+// @ Deprecated
 class JobTest extends AnyFunSpec {
   import org.corerda.service.types.IntegerImpl._
 
@@ -23,7 +24,7 @@ class JobTest extends AnyFunSpec {
         val expected =
           List(10, 20, 30, 40, 50, 60, 70, 24, 27, 30, 33, 36, 39, 42, 45, 48)
 
-        assert(foldTree(myJob) == expected)
+        assert(eval(myJob) == expected)
       }
     }
   }

--- a/src/test/scala/org/corerda/rules/core/TreeOpsTest.scala
+++ b/src/test/scala/org/corerda/rules/core/TreeOpsTest.scala
@@ -19,18 +19,18 @@ class TreeOpsTest extends AnyFunSpec {
   // test type = List[Int]
   import org.corerda.rules.core.TreeOps._
   describe("TreeOps Test") {
-    describe("given a plan (graph as Map of nodes), toTree[T] ") {
-      it("Should split and parse into a List[Job[T]]") {
-        val expected = List(
-          Tree.stem(WriterCmp("sink_B"),
-            Tree.branch(BinderCmp("merge"),
-              Tree.stem(FxCmp(List("if_div:3"), "left"),
-                Tree.leaf(ReaderCmp(50, "source_B"))),
-              Tree.stem(FxCmp(List("if_div:7"), "left"),
-                Tree.leaf(ReaderCmp(50, "source_B"))))),
-          Tree.stem(WriterCmp("sink_A"),
-            Tree.leaf(ReaderCmp(10, "source_A"))))
-        assert(toTree(myPlan) == expected)
+    // TODO - remove comment
+    // toTree[T] Test @ deprecated
+    //    -> behaviour change from Tag-less Initial to TF, removed Job eval
+      describe("given a plan (graph as Map of nodes), runAST[T] ") {
+        it("Should return the root results of the AST evaluation") {
+          val expected = List(
+            ExprTree(
+              List(10, 20, 30, 40, 50, 60, 70, 24, 27, 30, 33, 36, 39, 42, 45, 48)),
+            ExprTree(
+              List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)))
+          assert(runAST(myPlan) == expected)
+        }
       }
     }
   }


### PR DESCRIPTION
#18 
After evaluating and reviewing the Tagless-final PD approach I've discovered that I was using Tagless-initial.

Refactored code to TF to reduce Redundancy in evaluation.